### PR TITLE
Field `created_at` smazán u produktových endpointů

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1488,7 +1488,6 @@ Returns project's products.
                         "id": "1693",
                         "output_changed_at": null,
                         "updated_at": "2016-04-28T17:18:50+00:00",
-                        "created_at": "2016-03-27T17:18:45+00:00",
                         "data": {
                             "CATEGORYTEXT": "Tonery do tiskáren > Kompatibilní tonery",
                             "DELIVERY_DATE": "0",
@@ -1518,7 +1517,6 @@ Returns project's products.
                         "id": "1694",
                         "output_changed_at": null,
                         "updated_at": "2016-04-28T17:18:50+00:00",
-                        "created_at": "2016-03-27T17:18:45+00:00",
                         "data": {
                             "CATEGORYTEXT": "Tonery do tiskáren > Kompatibilní tonery",
                             "DELIVERY_DATE": "0",
@@ -1571,7 +1569,6 @@ Returns a product with the given ID.
                 "id": "1693",
                 "output_changed_at": null,
                 "updated_at": "2016-04-28T17:18:50+00:00",
-                "created_at": "2016-03-27T17:18:45+00:00",
                 "data": {
                     "CATEGORYTEXT": "Tonery do tiskáren > Kompatibilní tonery",
                     "DELIVERY_DATE": "0",
@@ -1634,7 +1631,6 @@ to force Mergado to refresh the product (apply rules) during the next (lazy) reb
                 "id": "1693",
                 "output_changed_at": null,
                 "updated_at": "2017-05-21T00:00:00+00:00",
-                "created_at": "2016-03-27T17:18:45+00:00",
                 "data": {
                     "CATEGORYTEXT": "Tonery do tiskáren > Kompatibilní tonery",
                     "DELIVERY_DATE": "0",
@@ -1684,7 +1680,6 @@ Returns products that satisfy a condition defined by the given query.
                         "id": "3838",
                         "output_changed_at": "2016-04-25T17:20:44+00:00",
                         "updated_at": "2016-04-25T16:42:50+00:00",
-                        "created_at": "2016-03-27T17:18:45+00:00",
                         "data": {
                             "CATEGORYTEXT": "Text kategorie",
                             "DELIVERY_DATE": "0",
@@ -1728,7 +1723,6 @@ Returns products that satisfy a condition defined by the given query.
                         "id": "3839",
                         "output_changed_at": "2016-04-25T17:20:44+00:00",
                         "updated_at": "2016-04-25T16:42:50+00:00",
-                        "created_at": "2016-03-27T17:18:45+00:00",
                         "data": {
                             "CATEGORYTEXT": "Text kategorie",
                             "DELIVERY_DATE": "0",


### PR DESCRIPTION
- informace o vytvoření / smazání produktu jsou nyní k dizpozici na endpointu pro párování `/projects/{id}/pairings/`

---

_**Edit:** Nebylo zatím implementováno (my bad), má ale smysl to z tohoto endpointu vyhodit (zrychlí se tím, protože nebude potřeba tahat informace z tabulky navíc) a proto to tu nechávám._